### PR TITLE
Detect orientation-change on iOS devices & re-scale screen (CSS-only fix)

### DIFF
--- a/header.php
+++ b/header.php
@@ -34,7 +34,7 @@
 
   ?></title>
     <meta charset="<?php bloginfo( 'charset' ); ?>" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, maximum-scale=1.0, minimum-scale=1.0, initial-scale=1">
     <?php if ( is_singular() && get_option( 'thread_comments' ) ) wp_enqueue_script( 'comment-reply' ); ?>
     <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 


### PR DESCRIPTION
Forces iOS Safari to update the screensize on orientation-change (landscape/portrait)

This blog post details the problem that's fixed.

My client that I'm using this theme for has a device lib. We've tested & verified this fix on the following devices (and don't see any negatives on desktop breakpoints):
- iPhone 4S iOS 6.0
- iPad Mini iOS 6.1.3
- iPad 3 iOS 6.1.3
- iPad 2 iOS 5.1
- HTC Thunderbolt Android 2.3.4
- Samsung Galaxy S3 Android 4.1.1
- Samsung Galaxy S android 2.3.5
